### PR TITLE
[DOC] documentation for align_multiple

### DIFF
--- a/include/seqan3/alignment/multiple/align_multiple.hpp
+++ b/include/seqan3/alignment/multiple/align_multiple.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides the algorithm seqan3::align_multiple.
+ * \brief Provides the algorithm seqan3::align_multiple for multiple sequence alignment.
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
  * \author Joerg Winkler <j.winkler AT fu-berlin.de>
  * \author Simon Sasse <simon.sasse AT fu-berlin.de>
@@ -31,13 +31,40 @@ static_assert(false, "You need to have seqan 2.x");
 namespace seqan3::align_cfg
 {
 
+/*!\brief The standard configuration for multiple sequence alignment.
+ * \ingroup multiple_alignment
+ * \details
+ *
+ * The standard configuration values are adapted from SeqAn2 in order to provide the same behaviour.
+ *
+ *   * general gap score: -1
+ *   * additional gap open score: -13
+ *   * band constraints: none
+ *   * scoring for amino acid sequences: Blosum62 matrix
+ *   * scoring for nucleotide sequences: +5 (match) and -4 (mismatch)
+ */
 constexpr configuration msa_default_configuration = gap{gap_scheme{gap_score{-1}, gap_open_score{-13}}};
 
-}
+} // namespace seqan3::align_cfg
 
 namespace seqan3
 {
 
+/*!\brief The algorithm for multiple sequence alignment.
+ * \ingroup multiple_alignment
+ * \tparam range_t Type of the input sequences, must model std::ranges::forward_range.
+ * \tparam config_t Type of the configuration; defaults to the type of seqan3::align_cfg::msa_default_configuration.
+ * \param input A vector of sequences that you want to align.
+ * \param config A configuration object that stores the settings for the algorithm;
+ *               defaults to seqan3::align_cfg::msa_default_configuration.
+ * \return The multiple sequence alignment as a vector of gapped sequences.
+ * \details
+ *
+ * Computes a multiple sequence alignment from the given input sequences, using a consistency-based progressive
+ * alignment algorithm on a graph of sequence segments. You can use the configuration object to
+ * specify various parameters, like gap scores, alignment scores and band constraints. The return type is
+ * `std::vector<std::vector<gapped_alphabet_type>>`, with the inner type derived from the input sequence type.
+ */
 template <std::ranges::forward_range range_t, typename config_t = decltype(align_cfg::msa_default_configuration)>
 auto align_multiple(std::vector<range_t> const & input, config_t config = align_cfg::msa_default_configuration)
 {

--- a/include/seqan3/alignment/multiple/detail/align_multiple_seqan2_adaptation.hpp
+++ b/include/seqan3/alignment/multiple/detail/align_multiple_seqan2_adaptation.hpp
@@ -165,8 +165,15 @@ private:
                       "The given MSA configuration is not valid.");
     }
 
+    /*!\brief Create the SeqAn2 scoring scheme based on the given SeqAn3 configuration.
+     * \tparam seqan3_configuration_t The type of the configuration object.
+     * \param config The configuration that contains scoring parameters.
+     * \return A SeqAn2 *MsaOptions* object with initialised scores.
+     */
     template <typename seqan3_configuration_t>
+    //!\cond
         requires seqan3_configuration_t::template exists<seqan3::align_cfg::scoring>()
+    //!\endcond
     auto initialise_scoring_scheme(seqan3_configuration_t const & config)
     {
         auto scoring_scheme = get<seqan3::align_cfg::scoring>(config).value;
@@ -199,8 +206,14 @@ private:
         return msaOpt;
     }
 
+    /*!\brief Create the SeqAn2 scoring scheme based on default values.
+     * \tparam seqan3_configuration_t The type of a configuration object, which does not contain scoring parameters.
+     * \return A SeqAn2 *MsaOptions* object with initialised scores.
+     */
     template <typename seqan3_configuration_t>
+    //!\cond
         requires !seqan3_configuration_t::template exists<seqan3::align_cfg::scoring>()
+    //!\endcond
     auto initialise_scoring_scheme(seqan3_configuration_t const &)
     {
         using score_type = std::conditional_t<std::same_as<alphabet_type, seqan::AminoAcid> ||


### PR DESCRIPTION
Note: It seems that Doxygen does not interpret the `SEQAN3_HAS_SEQAN2` macro correctly and currently skips all the files regarding MSA. This can be fixed in a future commit.